### PR TITLE
Add links to DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,3 +23,5 @@ Suggests:
     blob,
     testthat (>= 3.0.0)
 Config/testthat/edition: 3
+URL: https://extendr.github.io/b64/, https://github.com/extendr/b64
+BugReports: https://github.com/extendr/b64/issues


### PR DESCRIPTION
You may also consider adding the website link in the about section of the github homepage!